### PR TITLE
Build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 node_js:
   - '10'
 script:
-  - npm run build-storybook
+  - npm run build-docs
 after_success:
   - npm run snapshot
 branches:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "posttest": "npm run check",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o ./public",
+    "build-docs": "build-storybook -o ./public --docs",
     "snapshot": "PERCY_TOKEN=$PERCY_TOKEN percy-storybook --widths=320,1280 --build_dir=public"
   },
   "devDependencies": {


### PR DESCRIPTION
## Changes
Add `build-docs` command to build Storybook docs-mode. 

Update travis to publish the docs output instead.

## Impact
Docs mode will be deployed instead of normal Storybook with the default view to the canvas